### PR TITLE
Fix ingredients brackets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To avoid paying 100 USD/mo for Twitter API, this system uses IFTTT to feed likes
 - URL: `{lambda_function_uri}/publikes-ingest`
 - Content-Type: application/json
 - Headers: `x-secret: {secret}`
-- Content: `{"url": "<<<{LinkToTweet}>>>"}`
+- Content: `{"url": "<<<{{LinkToTweet}}>>>"}`
 
 ## How it works
 


### PR DESCRIPTION
https://help.ifttt.com/hc/en-us/articles/1260803042229-Troubleshooting-outbound-webhooks#Escapeanytextcontent